### PR TITLE
/contents より前の各画面クラスを作成 途中まで

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "ARGB",
+        "autofocus",
+        "autovalidate",
         "commentq",
         "Kamishibai",
         "signup",

--- a/withtone/lib/components/text_button_zero_padding.dart
+++ b/withtone/lib/components/text_button_zero_padding.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// padding が 0 の TextButton
+///
+/// 基本的に TextButton と同様に利用する.
+/// style は指定できない. ( padding 0 にする為にカスタマイズしている為 )
+class TextButtonZeroPadding extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final VoidCallback? onLongPress;
+  final ValueChanged<bool>? onHover;
+  final ValueChanged<bool>? onFocusChange;
+  final Clip clipBehavior;
+  final FocusNode? focusNode;
+  final bool autofocus;
+  final MaterialStatesController? statesController;
+  final Widget child;
+
+  // padding を消す為の style
+  // 参考: https://crieit.net/posts/Flutter-TextButton
+  final ButtonStyle _zeroPaddingStyle = ButtonStyle(
+    padding: MaterialStateProperty.all(EdgeInsets.zero),
+    minimumSize: MaterialStateProperty.all(Size.zero),
+    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+  );
+
+  TextButtonZeroPadding({
+    super.key,
+    this.onPressed,
+    this.onLongPress,
+    this.onHover,
+    this.onFocusChange,
+    this.focusNode,
+    this.autofocus = false,
+    this.clipBehavior = Clip.none,
+    this.statesController,
+    required this.child,
+  });
+
+  @override
+  Widget build(context) {
+    return TextButton(
+      onPressed: onPressed,
+      onLongPress: onLongPress,
+      onHover: onHover,
+      onFocusChange: onFocusChange,
+      style: _zeroPaddingStyle,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      clipBehavior: clipBehavior,
+      statesController: statesController,
+      child: child,
+    );
+  }
+}

--- a/withtone/lib/kamishibai.dart
+++ b/withtone/lib/kamishibai.dart
@@ -24,7 +24,7 @@ class Kamishibai extends StatefulWidget {
     /// 背景画像ファイルパス 例えば `assets/page_images/xxx.png`
     required this.assetPath,
 
-    /// 画面タップの遷移先. 例えば `[ '/login', '/content' ]`
+    /// 画面タップの遷移先. 例えば `[ '/', LoginPage.path ]`
     required this.nextPathList,
 
     /// pop する導線があるか

--- a/withtone/lib/routes.dart
+++ b/withtone/lib/routes.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:withtone/kamishibai.dart';
+import 'package:withtone/view/password_reissue/password_reissue_page.dart';
+import 'package:withtone/view/password_reissue_confirm/password_reissue_confirm_page.dart';
 
 /// ルーティング管理
 /// 基本的にインスタンス化せずに利用します
@@ -18,7 +20,7 @@ class Routes {
           nextPathList: [
             '/content',
             '/signup',
-            '/password_reissue',
+            PasswordReissuePage.path,
           ],
         ),
     '/signup': (context) => const Kamishibai(
@@ -28,17 +30,21 @@ class Routes {
             '/learning_community_search',
           ],
         ),
-    '/password_reissue': (context) => const Kamishibai(
-          assetPath: 'assets/page_images/パスワード再発行ページ.jpg',
-          nextPathList: [
-            '/password_reissue_confirm',
-          ],
-          existUserFlowOfPop: true,
-        ),
-    '/password_reissue_confirm': (context) => const Kamishibai(
-          assetPath: 'assets/page_images/パスワード再発行確認ページ.jpg',
-          nextPathList: ['/login'],
-        ),
+    PasswordReissuePage.path: (context) =>
+        // const Kamishibai(
+        //       assetPath: 'assets/page_images/パスワード再発行ページ.jpg',
+        //       nextPathList: [
+        //         PasswordReissueConfirmPage.path,
+        //       ],
+        //       existUserFlowOfPop: true,
+        //     ),
+        const PasswordReissuePage(),
+    PasswordReissueConfirmPage.path: (context) =>
+        // const Kamishibai(
+        //       assetPath: 'assets/page_images/パスワード再発行確認ページ.jpg',
+        //       nextPathList: ['/login'],
+        //     ),
+        const PasswordReissueConfirmPage(),
     '/learning_community_search': (context) => const Kamishibai(
           assetPath: 'assets/page_images/learning community search.png',
           nextPathList: ['/content'],

--- a/withtone/lib/routes.dart
+++ b/withtone/lib/routes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:withtone/kamishibai.dart';
+import 'package:withtone/view/login/login_page.dart';
 import 'package:withtone/view/password_reissue/password_reissue_page.dart';
 import 'package:withtone/view/password_reissue_confirm/password_reissue_confirm_page.dart';
 
@@ -13,20 +14,21 @@ class Routes {
   static final Map<String, Widget Function(BuildContext)> routes = {
     '/': (context) => const Kamishibai(
           assetPath: 'assets/page_images/Intro.png',
-          nextPathList: ['/login'],
+          nextPathList: [LoginPage.path],
         ),
-    '/login': (context) => const Kamishibai(
-          assetPath: 'assets/page_images/login.png',
-          nextPathList: [
-            '/content',
-            '/signup',
-            PasswordReissuePage.path,
-          ],
-        ),
+    LoginPage.path: (context) => LoginPage(),
+    // const Kamishibai(
+    //       assetPath: 'assets/page_images/login.png',
+    //       nextPathList: [
+    //         '/content',
+    //         '/signup',
+    //         PasswordReissuePage.path,
+    //       ],
+    //     ),
     '/signup': (context) => const Kamishibai(
           assetPath: 'assets/page_images/signup.png',
           nextPathList: [
-            '/login',
+            LoginPage.path,
             '/learning_community_search',
           ],
         ),

--- a/withtone/lib/view/login/login_page.dart
+++ b/withtone/lib/view/login/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:withtone/components/text_button_zero_padding.dart';
 import 'package:withtone/view/password_reissue/password_reissue_page.dart';
 
 class LoginPage extends StatelessWidget {
@@ -8,120 +9,163 @@ class LoginPage extends StatelessWidget {
 
   final _tab = <Widget>[
     const Padding(
-      padding: EdgeInsets.all(8.0),
+      padding: EdgeInsets.all(12),
       child: Tab(text: 'ログイン'),
     ),
     const Padding(
-      padding: EdgeInsets.all(8.0),
+      padding: EdgeInsets.all(12),
       child: Tab(text: '新規登録'),
     ),
   ];
 
-  /// スタートボタンをタップした時の挙動
-  void _onPressedStart(BuildContext context) {
-    showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        barrierColor: Colors.transparent,
-        builder: (context) {
-          return DefaultTabController(
-            length: _tab.length,
-            child: SizedBox(
-              height: MediaQuery.of(context).size.height * 0.75,
-              child: Stack(
-                alignment: AlignmentDirectional.bottomStart,
-                children: [
-                  Container(
-                    color: Theme.of(context).primaryColor,
-                    height: MediaQuery.of(context).size.height * 0.75,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        TabBar(
-                          tabs: _tab,
-                          labelColor: Colors.white,
-                          unselectedLabelColor:
-                              const Color.fromARGB(64, 255, 255, 255),
-                          dividerColor: Colors.transparent,
-                        ),
-                      ],
+  /// スタートボタンタップで表示されるログインモーダル
+  Widget _loginModal(BuildContext context) {
+    return ClipRRect(
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(20),
+        topRight: Radius.circular(20),
+      ),
+      child: DefaultTabController(
+        length: _tab.length,
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height * 0.75,
+          child: Stack(
+            alignment: AlignmentDirectional.bottomStart,
+            children: [
+              Container(
+                color: Theme.of(context).primaryColor,
+                height: MediaQuery.of(context).size.height * 0.75,
+                child: Column(
+                  children: <Widget>[
+                    TabBar(
+                      tabs: _tab,
+                      labelStyle: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      labelColor: Colors.white,
+                      unselectedLabelColor: const Color(0x40ffffff),
+                      dividerColor: Colors.transparent,
                     ),
-                  ),
-                  Container(
-                    color: Colors.white,
-                    height: MediaQuery.of(context).size.height * 0.65,
-                    child: SizedBox(
-                      width: double.infinity,
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                          children: [
-                            const Text('Welcome Back'),
-                            TextFormField(
-                              restorationId: 'life_story_field',
-                              focusNode: FocusNode(),
-                              decoration: const InputDecoration(
-                                border: OutlineInputBorder(),
-                                hintText: "メールアドレスを入力してください",
-                                labelText: "メールアドレス",
+                  ],
+                ),
+              ),
+              ClipRRect(
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(20),
+                  topRight: Radius.circular(20),
+                ),
+                child: Container(
+                  color: Colors.white,
+                  height: MediaQuery.of(context).size.height * 0.67,
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          const SizedBox(
+                            width: double.infinity,
+                            child: Text(
+                              'Welcome back',
+                              textAlign: TextAlign.start,
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 24,
                               ),
                             ),
-                            TextFormField(
-                              restorationId: 'life_story_field',
-                              focusNode: FocusNode(),
-                              decoration: const InputDecoration(
-                                border: OutlineInputBorder(),
-                                hintText: "パスワードを入力してください",
-                                labelText: "パスワード",
+                          ),
+                          const SizedBox(
+                            width: double.infinity,
+                            child: Text(
+                              'メールアドレス',
+                              textAlign: TextAlign.start,
+                              style: TextStyle(
+                                fontWeight: FontWeight.normal,
+                                fontSize: 12,
                               ),
                             ),
-                            OutlinedButton(
-                              onPressed: () =>
-                                  Navigator.pushNamed(context, '/content'),
-                              child: const Text('ログイン'),
+                          ),
+                          TextFormField(
+                            cursorColor: Colors.black,
+                            decoration: const InputDecoration(
+                              hintText: "メールアドレスを入力してください",
                             ),
-                            TextButton(
-                              onPressed: () => Navigator.pushNamed(
-                                context,
-                                PasswordReissuePage.path,
+                            focusNode: FocusNode(),
+                            maxLength: 40,
+                            autovalidateMode:
+                                AutovalidateMode.onUserInteraction,
+                            validator: (inputText) {
+                              // TODO(ケンティー): 各種バリデーションはちゃんと考えて定義する. 共通化して他の箇所でも利用したい.
+                              if (inputText == null || inputText == '') {
+                                return '入力してください';
+                              } else if (inputText.contains(' ')) {
+                                return 'スペースが含まれています';
+                              }
+                              return null;
+                            },
+                          ),
+                          TextFormField(
+                            restorationId: 'life_story_field',
+                            focusNode: FocusNode(),
+                            decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                              hintText: "パスワードを入力してください",
+                              labelText: "パスワード",
+                            ),
+                          ),
+                          OutlinedButton(
+                            onPressed: () =>
+                                Navigator.pushNamed(context, '/content'),
+                            child: const Text('ログイン'),
+                          ),
+                          Column(
+                            children: [
+                              const Text('パスワードをお忘れですか?'),
+                              TextButtonZeroPadding(
+                                onPressed: () => Navigator.pushNamed(
+                                  context,
+                                  PasswordReissuePage.path,
+                                ),
+                                child: const Text('Reset here'),
                               ),
-                              child: const Text('Reset here'),
-                            ),
-                            OutlinedButton(
-                              onPressed: () => Navigator.pushNamed(
-                                  context, '/learning_community_search'),
-                              child: const Text('新規登録'),
-                            ),
-                            const Text('OR SIGN IN WITH'),
-                            ButtonBar(
-                              alignment: MainAxisAlignment.center,
-                              children: [
-                                IconButton(
-                                  onPressed: () {},
-                                  icon: const Text('G'),
-                                ),
-                                IconButton(
-                                  onPressed: () {},
-                                  icon: const Text('F'),
-                                ),
-                                IconButton(
-                                  onPressed: () {},
-                                  icon: const Text('X'),
-                                ),
-                              ],
-                            )
-                          ],
-                        ),
+                            ],
+                          ),
+                          OutlinedButton(
+                            onPressed: () => Navigator.pushNamed(
+                                context, '/learning_community_search'),
+                            child: const Text('新規登録'),
+                          ),
+                          const Text('OR SIGN IN WITH'),
+                          ButtonBar(
+                            alignment: MainAxisAlignment.center,
+                            children: [
+                              IconButton(
+                                onPressed: () {},
+                                icon: const Text('G'),
+                              ),
+                              IconButton(
+                                onPressed: () {},
+                                icon: const Text('F'),
+                              ),
+                              IconButton(
+                                onPressed: () {},
+                                icon: const Text('X'),
+                              ),
+                            ],
+                          )
+                        ],
                       ),
                     ),
                   ),
-                ],
+                ),
               ),
-            ),
-          );
-        });
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   @override
@@ -173,7 +217,11 @@ class LoginPage extends StatelessWidget {
                         elevation: 20,
                       ),
                       onPressed: () {
-                        _onPressedStart(context);
+                        showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            barrierColor: Colors.transparent,
+                            builder: _loginModal);
                       },
                       child: const Text(
                         'スタート',

--- a/withtone/lib/view/login/login_page.dart
+++ b/withtone/lib/view/login/login_page.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:withtone/view/password_reissue/password_reissue_page.dart';
+
+class LoginPage extends StatelessWidget {
+  LoginPage({super.key});
+
+  static const String path = '/login';
+
+  final _tab = <Widget>[
+    const Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Tab(text: 'ログイン'),
+    ),
+    const Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Tab(text: '新規登録'),
+    ),
+  ];
+
+  /// スタートボタンをタップした時の挙動
+  void _onPressedStart(BuildContext context) {
+    showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        barrierColor: Colors.transparent,
+        builder: (context) {
+          return DefaultTabController(
+            length: _tab.length,
+            child: SizedBox(
+              height: MediaQuery.of(context).size.height * 0.75,
+              child: Stack(
+                alignment: AlignmentDirectional.bottomStart,
+                children: [
+                  Container(
+                    color: Theme.of(context).primaryColor,
+                    height: MediaQuery.of(context).size.height * 0.75,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        TabBar(
+                          tabs: _tab,
+                          labelColor: Colors.white,
+                          unselectedLabelColor:
+                              const Color.fromARGB(64, 255, 255, 255),
+                          dividerColor: Colors.transparent,
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    color: Colors.white,
+                    height: MediaQuery.of(context).size.height * 0.65,
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            const Text('Welcome Back'),
+                            TextFormField(
+                              restorationId: 'life_story_field',
+                              focusNode: FocusNode(),
+                              decoration: const InputDecoration(
+                                border: OutlineInputBorder(),
+                                hintText: "メールアドレスを入力してください",
+                                labelText: "メールアドレス",
+                              ),
+                            ),
+                            TextFormField(
+                              restorationId: 'life_story_field',
+                              focusNode: FocusNode(),
+                              decoration: const InputDecoration(
+                                border: OutlineInputBorder(),
+                                hintText: "パスワードを入力してください",
+                                labelText: "パスワード",
+                              ),
+                            ),
+                            OutlinedButton(
+                              onPressed: () =>
+                                  Navigator.pushNamed(context, '/content'),
+                              child: const Text('ログイン'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pushNamed(
+                                context,
+                                PasswordReissuePage.path,
+                              ),
+                              child: const Text('Reset here'),
+                            ),
+                            OutlinedButton(
+                              onPressed: () => Navigator.pushNamed(
+                                  context, '/learning_community_search'),
+                              child: const Text('新規登録'),
+                            ),
+                            const Text('OR SIGN IN WITH'),
+                            ButtonBar(
+                              alignment: MainAxisAlignment.center,
+                              children: [
+                                IconButton(
+                                  onPressed: () {},
+                                  icon: const Text('G'),
+                                ),
+                                IconButton(
+                                  onPressed: () {},
+                                  icon: const Text('F'),
+                                ),
+                                IconButton(
+                                  onPressed: () {},
+                                  icon: const Text('X'),
+                                ),
+                              ],
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        height: double.infinity,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: FractionalOffset.topCenter,
+            end: FractionalOffset.bottomCenter,
+            colors: [
+              Theme.of(context).colorScheme.secondary,
+              Theme.of(context).colorScheme.primary,
+            ],
+            stops: const [0.0, 1.0],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+              child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              const SizedBox(),
+              Column(
+                children: [
+                  const FlutterLogo(
+                    style: FlutterLogoStyle.horizontal,
+                    size: 200,
+                  ),
+                  Text(
+                    '音楽ソーシャル学習プラットフォーム',
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.53),
+                    ),
+                  ),
+                ],
+              ),
+              ButtonBar(
+                alignment: MainAxisAlignment.center,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 80),
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        fixedSize: const Size.fromWidth(double.maxFinite),
+                        surfaceTintColor: Colors.white,
+                        elevation: 20,
+                      ),
+                      onPressed: () {
+                        _onPressedStart(context);
+                      },
+                      child: const Text(
+                        'スタート',
+                        style: TextStyle(
+                          color: Color(0xff596E79),
+                          height: 60 / 18,
+                          fontWeight: FontWeight.w800,
+                          fontSize: 18,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          )),
+        ),
+      ),
+    );
+  }
+}

--- a/withtone/lib/view/password_reissue/password_reissue_page.dart
+++ b/withtone/lib/view/password_reissue/password_reissue_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:withtone/view/password_reissue_confirm/password_reissue_confirm_page.dart';
+
+/// パスワード再発行依頼を送信するページ
+class PasswordReissuePage extends StatefulWidget {
+  const PasswordReissuePage({super.key});
+
+  static const String path = '/password_reissue';
+
+  @override
+  State<PasswordReissuePage> createState() => _PasswordReissuePageState();
+}
+
+class _PasswordReissuePageState extends State<PasswordReissuePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Container(
+        alignment: Alignment.center,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              const Text('パスワードをお忘れですか？'),
+              const Text('登録時のメールアドレスを入力してください。'),
+              TextFormField(
+                restorationId: 'life_story_field',
+                focusNode: FocusNode(),
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: "メールアドレスを入力してください",
+                  labelText: "メールアドレス",
+                ),
+              ),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                    onPressed: () => Navigator.pushNamed(
+                          context,
+                          PasswordReissueConfirmPage.path,
+                        ),
+                    child: const Text('送信')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/withtone/lib/view/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/withtone/lib/view/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:withtone/view/login/login_page.dart';
 
 /// パスワード再発送信後に表示するページ
 class PasswordReissueConfirmPage extends StatefulWidget {
@@ -33,7 +34,7 @@ class _PasswordReissueConfirmPageState
                 child: ElevatedButton(
                     onPressed: () => Navigator.pushNamed(
                           context,
-                          '/login',
+                          LoginPage.path,
                         ),
                     child: const Text('ログインページへ')),
               ),

--- a/withtone/lib/view/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/withtone/lib/view/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// パスワード再発送信後に表示するページ
+class PasswordReissueConfirmPage extends StatefulWidget {
+  const PasswordReissueConfirmPage({super.key});
+
+  static const String path = '/password_reissue_confirm';
+
+  @override
+  State<PasswordReissueConfirmPage> createState() =>
+      _PasswordReissueConfirmPageState();
+}
+
+class _PasswordReissueConfirmPageState
+    extends State<PasswordReissueConfirmPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Container(
+        alignment: Alignment.center,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              const Text('メールを送信しました'),
+              const Text('パスワードを再発行しました。'),
+              const Text('メールを送信しましたのでご確認ください。'),
+              const Text('10秒後にログインページに戻ります。'),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                    onPressed: () => Navigator.pushNamed(
+                          context,
+                          '/login',
+                        ),
+                    child: const Text('ログインページへ')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## やりたかったこと

以下ページ仮作成. ディレクトリ構成変えるので, 途中までで一旦 RV していただく.

- /intro ( / )
- /login
- /signup
- /password_reissue
- /password_reissue_confirm

## やったこと

- / から /contents 前までの画面を仮作成した.

## やってないこと
- ログイン ←→ 新規登録 で モーダルの内容を切り替える
- 入力フォームバリデーション作り込み
- アイコン

## 確認

https://gyazo.com/8f6d3f319d36f46447536b7b87373906
https://gyazo.com/0c61ea22b105229299d0ec939d7c2c28
https://gyazo.com/1c8f15878641caadd066d4b732c14477
https://gyazo.com/4e756b773a98270d97855de79bcbbbbe
