### PR TITLE
パスワード再設定関連のページの UI 作成

### DIFF
--- a/lib/views/components/primary_button.dart
+++ b/lib/views/components/primary_button.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// アプリ上でよく利用するボタン
+///
+/// ButtonBar とは分けた方が良いかもだが、一旦このまま共通化する
+class PrimaryButton extends StatelessWidget {
+  ///ボタンに表示するラベル文言
+  final String label;
+
+  /// ボタンタップで発火する処理
+  final VoidCallback? onPressed;
+  const PrimaryButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+  });
+
+  final TextStyle _style = const TextStyle(
+    height: 60 / 18,
+    fontWeight: FontWeight.w800,
+    fontSize: 18,
+  );
+
+  @override
+  Widget build(context) {
+    return ButtonBar(
+      alignment: MainAxisAlignment.center,
+      children: [
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            fixedSize: const Size.fromWidth(double.maxFinite),
+            backgroundColor: const Color(0xff005792),
+            foregroundColor: const Color(0xffffffff),
+            surfaceTintColor: const Color(0xff005792),
+            elevation: 0,
+          ),
+          onPressed: onPressed,
+          child: Text(label, style: _style),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/pages/password_reissue/password_reissue_page.dart
+++ b/lib/views/pages/password_reissue/password_reissue_page.dart
@@ -21,7 +21,6 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: Column(
             children: [
-              const SizedBox(height: 20), // 適当な余白
               const SizedBox(
                 width: double.infinity,
                 child: Text(
@@ -30,7 +29,7 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
                 ),
               ),
-              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(height: 40), // 適当な余白
               const SizedBox(
                 width: double.infinity,
                 child: Text(
@@ -39,17 +38,6 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
                 ),
               ),
               const SizedBox(height: 40), // 適当な余白
-              const SizedBox(
-                width: double.infinity,
-                child: Text(
-                  'メールアドレス',
-                  textAlign: TextAlign.start,
-                  style: TextStyle(
-                    fontWeight: FontWeight.normal,
-                    fontSize: 12,
-                  ),
-                ),
-              ),
               TextFormField(
                 cursorColor: Colors.black,
                 decoration: const InputDecoration(
@@ -69,7 +57,7 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
                   return null;
                 },
               ),
-              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(height: 40), // 適当な余白
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(

--- a/lib/views/pages/password_reissue/password_reissue_page.dart
+++ b/lib/views/pages/password_reissue/password_reissue_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:withtone/views/components/primary_button.dart';
 import 'package:withtone/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart';
 
 /// パスワード再発行依頼を送信するページ
@@ -58,21 +59,12 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
                 },
               ),
               const SizedBox(height: 40), // 適当な余白
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      fixedSize: const Size.fromWidth(double.maxFinite),
-                      backgroundColor: const Color(0xFFF73F96),
-                      foregroundColor: const Color(0xffffffff),
-                      surfaceTintColor: const Color(0xFFF73F96),
-                      elevation: 0,
-                    ),
-                    onPressed: () => Navigator.pushNamed(
-                          context,
-                          PasswordReissueConfirmPage.path,
-                        ),
-                    child: const Text('送信する')),
+              PrimaryButton(
+                label: '送信する',
+                onPressed: () => Navigator.pushNamed(
+                  context,
+                  PasswordReissueConfirmPage.path,
+                ),
               ),
             ],
           ),

--- a/lib/views/pages/password_reissue/password_reissue_page.dart
+++ b/lib/views/pages/password_reissue/password_reissue_page.dart
@@ -35,12 +35,11 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
               const SizedBox(
                 width: double.infinity,
                 child: Text(
-                  '登録時のメールアドレスを入力してください。',
+                  '登録時のメールアドレスを入力してください。再設定用のメールを送信します。',
                   textAlign: TextAlign.start,
                 ),
               ),
               const SizedBox(height: 40), // 適当な余白
-
               const SizedBox(
                 width: double.infinity,
                 child: Text(
@@ -72,7 +71,6 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
                 },
               ),
               const SizedBox(height: 20), // 適当な余白
-
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(

--- a/lib/views/pages/password_reissue/password_reissue_page.dart
+++ b/lib/views/pages/password_reissue/password_reissue_page.dart
@@ -16,8 +16,7 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: Container(
-        alignment: Alignment.center,
+      body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: Column(

--- a/lib/views/pages/password_reissue/password_reissue_page.dart
+++ b/lib/views/pages/password_reissue/password_reissue_page.dart
@@ -21,27 +21,73 @@ class _PasswordReissuePageState extends State<PasswordReissuePage> {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
-              const Text('パスワードをお忘れですか？'),
-              const Text('登録時のメールアドレスを入力してください。'),
+              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  'パスワードをお忘れですか？',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
+                ),
+              ),
+              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  '登録時のメールアドレスを入力してください。',
+                  textAlign: TextAlign.start,
+                ),
+              ),
+              const SizedBox(height: 40), // 適当な余白
+
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  'メールアドレス',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontWeight: FontWeight.normal,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
               TextFormField(
-                restorationId: 'life_story_field',
-                focusNode: FocusNode(),
+                cursorColor: Colors.black,
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
                   hintText: "メールアドレスを入力してください",
-                  labelText: "メールアドレス",
                 ),
+                focusNode: FocusNode(),
+                maxLength: 40,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                validator: (inputText) {
+                  // TODO(ケンティー): 各種バリデーションはちゃんと考えて定義する. 共通化して他の箇所でも利用したい.
+                  if (inputText == null || inputText == '') {
+                    return '入力してください';
+                  } else if (inputText.contains(' ')) {
+                    return 'スペースが含まれています';
+                  }
+                  return null;
+                },
               ),
+              const SizedBox(height: 20), // 適当な余白
+
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      fixedSize: const Size.fromWidth(double.maxFinite),
+                      backgroundColor: const Color(0xFFF73F96),
+                      foregroundColor: const Color(0xffffffff),
+                      surfaceTintColor: const Color(0xFFF73F96),
+                      elevation: 0,
+                    ),
                     onPressed: () => Navigator.pushNamed(
                           context,
                           PasswordReissueConfirmPage.path,
                         ),
-                    child: const Text('送信')),
+                    child: const Text('送信する')),
               ),
             ],
           ),

--- a/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -37,7 +37,7 @@ class _PasswordReissueConfirmPageState
               const SizedBox(
                 width: double.infinity,
                 child: Text(
-                  'パスワードを再発行しました。メールを送信しましたのでご確認ください。',
+                  'パスワード再設定用のメールを送信しました。メール内のリンクから新しいパスワードを設定してください。',
                   textAlign: TextAlign.start,
                 ),
               ),

--- a/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -23,15 +23,36 @@ class _PasswordReissueConfirmPageState
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
-              const Text('メールを送信しました'),
-              const Text('パスワードを再発行しました。'),
-              const Text('メールを送信しましたのでご確認ください。'),
-              const Text('10秒後にログインページに戻ります。'),
+              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  'メールを送信しました',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
+                ),
+              ),
+              const SizedBox(height: 20), // 適当な余白
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  'パスワードを再発行しました。メールを送信しましたのでご確認ください。',
+                  textAlign: TextAlign.start,
+                ),
+              ),
+              const SizedBox(height: 40), // 適当な余白
+
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      fixedSize: const Size.fromWidth(double.maxFinite),
+                      backgroundColor: const Color(0xFFF73F96),
+                      foregroundColor: const Color(0xffffffff),
+                      surfaceTintColor: const Color(0xFFF73F96),
+                      elevation: 0,
+                    ),
                     onPressed: () => Navigator.pushNamed(
                           context,
                           IntroPage.path,

--- a/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -18,50 +18,47 @@ class _PasswordReissueConfirmPageState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: Container(
-        alignment: Alignment.center,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0),
-          child: Column(
-            children: [
-              const SizedBox(height: 20), // 適当な余白
-              const SizedBox(
-                width: double.infinity,
-                child: Text(
-                  'メールを送信しました',
-                  textAlign: TextAlign.start,
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
-                ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+        child: Column(
+          children: [
+            const SizedBox(height: 20), // 適当な余白
+            const SizedBox(
+              width: double.infinity,
+              child: Text(
+                'メールを送信しました',
+                textAlign: TextAlign.start,
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
               ),
-              const SizedBox(height: 20), // 適当な余白
-              const SizedBox(
-                width: double.infinity,
-                child: Text(
-                  'パスワード再設定用のメールを送信しました。メール内のリンクから新しいパスワードを設定してください。',
-                  textAlign: TextAlign.start,
-                ),
+            ),
+            const SizedBox(height: 20), // 適当な余白
+            const SizedBox(
+              width: double.infinity,
+              child: Text(
+                'パスワード再設定用のメールを送信しました。メール内のリンクから新しいパスワードを設定してください。',
+                textAlign: TextAlign.start,
               ),
-              const SizedBox(height: 40), // 適当な余白
+            ),
+            const SizedBox(height: 40), // 適当な余白
 
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      fixedSize: const Size.fromWidth(double.maxFinite),
-                      backgroundColor: const Color(0xFFF73F96),
-                      foregroundColor: const Color(0xffffffff),
-                      surfaceTintColor: const Color(0xFFF73F96),
-                      elevation: 0,
-                    ),
-                    onPressed: () => Navigator.pushNamed(
-                          context,
-                          IntroPage.path,
-                          arguments: IntroPageArguments(showModal: true),
-                        ),
-                    child: const Text('ログインページへ')),
-              ),
-            ],
-          ),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    fixedSize: const Size.fromWidth(double.maxFinite),
+                    backgroundColor: const Color(0xFFF73F96),
+                    foregroundColor: const Color(0xffffffff),
+                    surfaceTintColor: const Color(0xFFF73F96),
+                    elevation: 0,
+                  ),
+                  onPressed: () => Navigator.pushNamed(
+                        context,
+                        IntroPage.path,
+                        arguments: IntroPageArguments(showModal: true),
+                      ),
+                  child: const Text('ログインページへ')),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -22,7 +22,6 @@ class _PasswordReissueConfirmPageState
         padding: const EdgeInsets.symmetric(horizontal: 20.0),
         child: Column(
           children: [
-            const SizedBox(height: 20), // 適当な余白
             const SizedBox(
               width: double.infinity,
               child: Text(
@@ -31,7 +30,7 @@ class _PasswordReissueConfirmPageState
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
               ),
             ),
-            const SizedBox(height: 20), // 適当な余白
+            const SizedBox(height: 40), // 適当な余白
             const SizedBox(
               width: double.infinity,
               child: Text(

--- a/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
+++ b/lib/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:withtone/views/components/primary_button.dart';
 import 'package:withtone/views/pages/intro/intro_page.dart';
 
 /// パスワード再発送信後に表示するページ
@@ -39,23 +40,13 @@ class _PasswordReissueConfirmPageState
               ),
             ),
             const SizedBox(height: 40), // 適当な余白
-
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    fixedSize: const Size.fromWidth(double.maxFinite),
-                    backgroundColor: const Color(0xFFF73F96),
-                    foregroundColor: const Color(0xffffffff),
-                    surfaceTintColor: const Color(0xFFF73F96),
-                    elevation: 0,
-                  ),
-                  onPressed: () => Navigator.pushNamed(
-                        context,
-                        IntroPage.path,
-                        arguments: IntroPageArguments(showModal: true),
-                      ),
-                  child: const Text('ログインページへ')),
+            PrimaryButton(
+              label: 'ログインページへ',
+              onPressed: () => Navigator.pushNamed(
+                context,
+                IntroPage.path,
+                arguments: IntroPageArguments(showModal: true),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## やりたかったこと

パスワード再発行ページ, パスワード再発行確認ページのレイアウト作成.

## やったこと

Figma に沿って UI を作成した. Figma が とりあえず文言置いた, くらいに見えたので, 細かいレイアウトや文言はよしなに調整しました.
https://gyazo.com/f14a77d57fcbb8e0b868e3d10962dacd

### 調整箇所

- タイトルは Login の "Welcome Back" と同じスタイルにした.
- 文言全般, 左揃えにした.
- パスワード再発行ページ の 文言だけだと, メアドを送信したらどうなるか, が書かれていなかったのでユーザー目線不親切だと思ったので, 「再設定用のメールを送信します。」の文言を追加した。それに合わせて、パスワード再発行確認ページの文言を調整した.
- パスワード再発行確認ページの 「10 秒後にログインページに戻ります。」について、別になくても困らない機能なので削除した。個人的にwebぽくて, ないほうがシンプルになると判断した.
- パスワード再発行確認ページの「パスワードを再発行しました。」は,ユーザーの好みのパスワードを設定できる想定挙動と一致しないので削除した.