### PR TITLE
feat: Introページにロゴ反映とバージョン表記を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "commentq",
         "Kamishibai",
         "LTRB",
+        "mainlogo",
         "signup",
         "thankyouf",
         "thankyouq",

--- a/lib/views/pages/intro/intro_page.dart
+++ b/lib/views/pages/intro/intro_page.dart
@@ -171,9 +171,9 @@ class _IntroPageState extends State<IntroPage> {
                 const SizedBox(),
                 Column(
                   children: [
-                    const FlutterLogo(
-                      style: FlutterLogoStyle.horizontal,
-                      size: 200,
+                    SizedBox(
+                      width: 300,
+                      child: Image.asset('assets/logo/mainlogo.png'),
                     ),
                     Text(
                       '音楽ソーシャル学習プラットフォーム',
@@ -181,37 +181,47 @@ class _IntroPageState extends State<IntroPage> {
                     ),
                   ],
                 ),
-                ButtonBar(
-                  alignment: MainAxisAlignment.center,
+                Column(
                   children: [
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 80),
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          fixedSize: const Size.fromWidth(double.maxFinite),
-                          backgroundColor: const Color(0xffffffff),
-                          foregroundColor: const Color(0xff596E79),
-                          surfaceTintColor: const Color(0xffffffff),
-                          elevation: 20,
-                        ),
-                        onPressed: autoShowModal
-                            ? null
-                            : () => showModalBottomSheet(
-                                  context: context,
-                                  isScrollControlled: true,
-                                  barrierColor: Colors.transparent,
-                                  builder: startModalBuilder,
-                                ),
-                        child: const Text(
-                          'スタート',
-                          style: TextStyle(
-                            height: 60 / 18,
-                            fontWeight: FontWeight.w800,
-                            fontSize: 18,
+                    ButtonBar(
+                      alignment: MainAxisAlignment.center,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 80),
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              fixedSize: const Size.fromWidth(double.maxFinite),
+                              backgroundColor: const Color(0xffffffff),
+                              foregroundColor: const Color(0xff596E79),
+                              surfaceTintColor: const Color(0xffffffff),
+                              elevation: 20,
+                            ),
+                            onPressed: autoShowModal
+                                ? null
+                                : () => showModalBottomSheet(
+                                      context: context,
+                                      isScrollControlled: true,
+                                      barrierColor: Colors.transparent,
+                                      builder: startModalBuilder,
+                                    ),
+                            child: const Text(
+                              'スタート',
+                              style: TextStyle(
+                                height: 60 / 18,
+                                fontWeight: FontWeight.w800,
+                                fontSize: 18,
+                              ),
+                            ),
                           ),
                         ),
-                      ),
+                      ],
                     ),
+                    const Text(
+                      'dev版 v0.0.1(99)',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    )
                   ],
                 ),
               ],

--- a/lib/views/pages/intro/intro_page.dart
+++ b/lib/views/pages/intro/intro_page.dart
@@ -149,6 +149,7 @@ class _IntroPageState extends State<IntroPage> {
       });
     }
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Container(
         height: double.infinity,
         width: double.infinity,


### PR DESCRIPTION
## やったこと

タイトル通り. [a06f088](https://github.com/Mayumi-Nakabayashi/withTone/pull/11/commits/a06f08803eb43287707f741e2585f3ea09b449df)

<img width="402" alt="スクリーンショット 2023-08-16 8 28 05" src="https://github.com/Mayumi-Nakabayashi/withTone/assets/38717219/28ab8b2e-12c1-433e-97a0-443782d2e8bc">

## ついでにやったこと

入力中のキーボードがIntroのレイアウトに干渉する不具合を修正しました [c79499f](https://github.com/Mayumi-Nakabayashi/withTone/pull/11/commits/c79499f546b097c8dadd6f72fb86c66ac7b61be1)
