### PR TITLE
upload_question_page作成

### DIFF
--- a/lib/views/pages/upload_question_page.dart
+++ b/lib/views/pages/upload_question_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:withtone/views/components/text/orange_text.dart';
+
+class UploadQuestionPage extends StatefulWidget {
+  const UploadQuestionPage({super.key});
+
+  static const String path = '/uploadQuestion';
+
+  @override
+  State<UploadQuestionPage> createState() => _UploadQuestionPageState();
+}
+
+class ButtonItem {
+  final String label;
+  bool isSelected = false;
+  ButtonItem({required this.label, this.isSelected = false});
+}
+
+class _UploadQuestionPageState extends State<UploadQuestionPage> {
+  List<ButtonItem> buttonItems = [
+    ButtonItem(label: 'はい'),
+    ButtonItem(label: 'いいえ'),
+  ];
+  List<ButtonItem> buttonItem = [];
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          SizedBox(
+            child: Image.asset(
+              'assets/page_images/upload_inst.jpg',
+              fit: BoxFit.cover,
+            ),
+          ),
+          Container(
+            color: const Color.fromRGBO(33, 33, 33, 0.93),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(
+                  height: 50,
+                ),
+
+                ///TODOバックボタンのアイコンを変更or相談する。
+                ///TODOバックボタンのロジックを書く
+                const BackButton(
+                  color: Colors.white,
+                ),
+                const SizedBox(
+                  height: 190,
+                ),
+                const OrangeText(label: '動画や写真で質問しますか？'),
+
+                Expanded(
+                  child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: buttonItems.length,
+                      itemBuilder: (context, index) {
+                        return ElevatedButton(
+                          onPressed: () {
+                            setState(() {
+                              for (var buttonItem in buttonItems) {
+                                buttonItem.isSelected = false;
+                              }
+                              buttonItems[index].isSelected = true;
+                            });
+                          },
+                          style: ElevatedButton.styleFrom(
+                            fixedSize: const Size.fromWidth(double.maxFinite),
+                            // ボタンの背景色を設定
+                            backgroundColor: Colors.transparent,
+                            // ボタンの文字色を設定
+                            side: BorderSide(
+                              color: buttonItems[index].isSelected
+                                  ? Color.fromRGBO(0, 87, 146, 1)
+                                  : Colors.white,
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            buttonItems[index].label,
+                            style: const TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        );
+                      }),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## やったこと
upload_question_pageの作成

- ボタン項目が、1つ選択できる仕様にした。

## やってないこと
- BackButtonのアイコンの変更とロジック作成
- routeの設定

Figma | 実装UI
-
<img width="200" alt="learning community search" src="https://github.com/Mayumi-Nakabayashi/withTone/assets/64653733/10c6ba39-f86a-4c86-8274-7e6fbf236bff">
- | - <img width="200" alt="learning community search" src="https://github.com/Mayumi-Nakabayashi/withTone/assets/64653733/4a66e58d-eed2-4bb9-86cc-1f71c08c5cde">
- 


