### PR TITLE
upload_fb_pageの作成

### DIFF
--- a/lib/views/pages/upload_fb.dart
+++ b/lib/views/pages/upload_fb.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:withtone/views/components/text/orange_text.dart';
+
+class UploadFbPage extends StatefulWidget {
+  const UploadFbPage({super.key});
+
+  static const String path = '/uploadFb';
+
+  @override
+  State<UploadFbPage> createState() => _UploadFbPageState();
+}
+
+class ButtonItem {
+  final String label;
+  bool isSelected = false;
+  ButtonItem({
+    required this.label,
+    this.isSelected = false,
+  });
+}
+
+class _UploadFbPageState extends State<UploadFbPage> {
+  List<ButtonItem> buttonItems = [
+    ButtonItem(label: '演奏に対するフィードバック'),
+    ButtonItem(label: 'おすすめの練習方法を教えてください'),
+    ButtonItem(label: 'ティップスを紹介する'),
+  ];
+  List<ButtonItem> buttonItem = [];
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          SizedBox(
+            child: Image.asset(
+              'assets/page_images/upload_inst.jpg',
+              fit: BoxFit.cover,
+            ),
+          ),
+          Container(
+            color: const Color.fromRGBO(33, 33, 33, 0.93),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(
+                  height: 50,
+                ),
+
+                ///TODOバックボタンのアイコンを変更or相談する。
+                ///TODOバックボタンのロジックを書く
+                const BackButton(
+                  color: Colors.white,
+                ),
+                const SizedBox(
+                  height: 190,
+                ),
+                const OrangeText(label: 'あなたの希望を教えてください'),
+
+                Expanded(
+                  child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: buttonItems.length,
+                      itemBuilder: (context, index) {
+                        return ElevatedButton(
+                          onPressed: () {
+                            setState(() {
+                              for (var buttonItem in buttonItems) {
+                                buttonItem.isSelected = false;
+                              }
+                              buttonItems[index].isSelected = true;
+                            });
+                          },
+                          style: ElevatedButton.styleFrom(
+                            fixedSize: const Size.fromWidth(double.maxFinite),
+                            // ボタンの背景色を設定
+                            backgroundColor: Colors.transparent,
+                            // ボタンの文字色を設定
+                            side: BorderSide(
+                              color: buttonItems[index].isSelected
+                                  ? Color.fromRGBO(0, 87, 146, 1)
+                                  : Colors.white,
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            buttonItems[index].label,
+                            style: const TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        );
+                      }),
+                ),
+                const SizedBox(
+                  height: 150,
+                ),
+                Center(
+                  child: SizedBox(
+                    height: 42,
+                    width: 260,
+                    child: ElevatedButton(
+                      ///TODO画面を繋げる。
+                      onPressed: () {},
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Color.fromRGBO(0, 87, 146, 1),
+                        // グラデーション色を定義
+                      ),
+                      child: const Text(
+                        '次へ',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 背景
#14 で作成PRを出したが余計なファイルもプッシュしてしまい、
コンフリクトが起きてしまったので今回、別PRで作成した。

## やったこと
upload_fb_pageの作成

- ボタン項目が1つ選択できる仕様にしている。

## やってないこと
- BackButtonのアイコンの変更とロジック作成
- ボタンの位置の調整
- route遷移

Figma | 実装UI
-
<img width="200" alt="learning community search" src="https://github.com/Mayumi-Nakabayashi/withTone/assets/64653733/0107b963-147b-480b-8b27-9730e0c8dbe8">
- | -
<img width="200" alt="learning community search" src="https://github.com/Mayumi-Nakabayashi/withTone/assets/64653733/457850b1-9e61-4972-875a-6d83e245b6fa">
- 

