### PR TITLE
Flutter バージョン管理ツールで Flutter バージョンを統一する

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+    "flutterSdkVersion": "3.10.6",
+    "flavors": {}
+  }

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+flutter 3.10.6-stable


### PR DESCRIPTION
## やりたかったこと

新規参画者が入る前に、バージョン管理ツールのプロジェクト設定を済ましておきたかった。

## 相談

自分は asdf 使っていて、ついでに入れちゃったけど良いでしょうか？
→ fvm 使ってないので、過不足あったら教えて下さい！（なので確認できず）

fvm参考: https://zenn.dev/altiveinc/articles/flutter-version-management

## 確認

asdf ... OK

```
 # withTone 以外だと 3.13.5-stable が適用されていて
apple@appurunoMacBook-Pro Mayumi-Nakabayashi % asdf current flutter
flutter         3.13.5-stable   /Users/apple/.tool-versions

apple@appurunoMacBook-Pro Mayumi-Nakabayashi % cd withTone/

# withTone/ 配下だと 3.10.6-stable が適用!
apple@appurunoMacBook-Pro withTone % asdf current flutter 
flutter         3.10.6-stable   /Users/apple/ghq/github.com/Mayumi-Nakabayashi/withTone/.tool-versions 
```


fvm ... 確認できず（不可能ではないけど手間かかりすぎるので fvm ユーザーにやってもらいたい...! ）