### PR TITLE
ユーザー名登録画面 UI 作成

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:withtone/app.dart';
 import 'package:withtone/splash_page.dart';
 import 'package:withtone/upload_inst_page.dart';
-import 'package:withtone/app.dart';
+import 'package:withtone/views/learning_community_search.dart';
 import 'package:withtone/views/pages/%20privacy/privacy_page.dart';
 import 'package:withtone/views/pages/account/account_page.dart';
 import 'package:withtone/views/pages/account_delete/account_stopdelete_delete_page.dart';
@@ -12,10 +13,10 @@ import 'package:withtone/views/pages/edit_profile/edit_profile_page.dart';
 import 'package:withtone/views/pages/home_page.dart';
 import 'package:withtone/views/pages/intro/intro_page.dart';
 import 'package:withtone/views/pages/login_mail/login_mail_page.dart';
-import 'package:withtone/views/learning_community_search.dart';
 import 'package:withtone/views/pages/password_reissue/password_reissue_page.dart';
 import 'package:withtone/views/pages/password_reissue_confirm/password_reissue_confirm_page.dart';
 import 'package:withtone/views/pages/profile/profile_page.dart';
+import 'package:withtone/views/pages/register_user/register_user_page.dart';
 import 'package:withtone/views/pages/setting/setting_page.dart';
 import 'package:withtone/views/pages/signup_mail/signup_mail.dart';
 import 'package:withtone/views/pages/upload_fb.dart';
@@ -57,8 +58,10 @@ class Routes {
     UploadVideoQuestionPage.path: (context) => const UploadVideoQuestionPage(),
     ArticlePage.path: (context) => const ArticlePage(),
     AccountStopdeletePage.path: (context) => const AccountStopdeletePage(),
-    AccountStopdeleteStopPage.path: (cotext) =>
+    AccountStopdeleteStopPage.path: (context) =>
         const AccountStopdeleteStopPage(),
-    AccountStopdeleteDeletePage.path: (context) => AccountStopdeleteDeletePage()
+    AccountStopdeleteDeletePage.path: (context) =>
+        const AccountStopdeleteDeletePage(),
+    RegisterUserPage.path: (constext) => const RegisterUserPage()
   };
 }

--- a/lib/views/pages/register_user/register_user_page.dart
+++ b/lib/views/pages/register_user/register_user_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:withtone/views/components/primary_button.dart';
+import 'package:withtone/views/learning_community_search.dart';
+
+/// ユーザー名を登録する画面
+class RegisterUserPage extends StatefulWidget {
+  const RegisterUserPage({super.key});
+
+  static const String path = '/register_user';
+
+  @override
+  State<RegisterUserPage> createState() => _RegisterUserPageState();
+}
+
+class _RegisterUserPageState extends State<RegisterUserPage> {
+  final userNameController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            children: [
+              const SizedBox(height: 100),
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  '名前を作成',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              const SizedBox(
+                width: double.infinity,
+                child: Text(
+                  '後でいつでも変更できます',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontWeight: FontWeight.normal,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+              TextFormField(
+                controller: userNameController,
+                cursorColor: Colors.black,
+                decoration: const InputDecoration(
+                  hintText: "木村なつみ",
+                ),
+                focusNode: FocusNode(),
+                maxLength: 40,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                validator: (inputText) {
+                  // TODO(ケンティー): 各種バリデーションはちゃんと考えて定義する. 共通化して他の箇所でも利用したい.
+                  if (inputText == null || inputText == '') {
+                    return '入力してください';
+                  } else if (inputText.contains(' ')) {
+                    return 'スペースが含まれています';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 40), // 適当な余白
+              PrimaryButton(
+                  label: '次へ',
+                  onPressed: () async {
+                    await Navigator.pushNamed(
+                      context,
+                      LeaningCommunitySearch.path,
+                    );
+                  }),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/signup_mail/emaill_send_check.dart
+++ b/lib/views/pages/signup_mail/emaill_send_check.dart
@@ -1,10 +1,11 @@
 // ignore_for_file: use_build_context_synchronously
 
 import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:withtone/views/components/primary_button.dart';
-import 'package:withtone/views/learning_community_search.dart';
+import 'package:withtone/views/pages/register_user/register_user_page.dart';
 
 class EmailSendCheck extends StatefulWidget {
   // 呼び出し元Widgetから受け取った後、変更をしないためfinalを宣言。
@@ -49,7 +50,7 @@ class EmailSendCheckState extends State<EmailSendCheck> {
       // emailVerifiedがtrueに変更されたタイミングでタイマーを停止
       timer.cancel();
       if (mounted) {
-        await Navigator.pushNamed(context, LeaningCommunitySearch.path);
+        await Navigator.pushNamed(context, RegisterUserPage.path);
       }
     });
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import firebase_analytics
 import firebase_auth
 import firebase_core
+import sign_in_with_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FirebaseAuthPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  firebase_auth
   firebase_core
 )
 


### PR DESCRIPTION
## 該当する issue 
#72 (残あり)

## やったこと

ユーザー名登録画面を作成した。
ついでに build した際に生じた自動生成ファイル（他に影響なし）を取り込んだ。

## やってないこと

ユーザー名登録の機能実装。
ユーザー管理はマイページらへんと衝突しそうなので、一旦UIだけ作ってしまう。
他にも issue に残があるので、子issue は作らず #72 で対応できればと。

## 確認

https://github.com/Mayumi-Nakabayashi/withTone/assets/38717219/3fdb53c8-71e2-4761-b7be-9e696b8be2d2




---

## その他
#131 マージ後に decelop にマージする。