### PR TITLE
ログアウト機能調整

### DIFF
--- a/lib/splash_page.dart
+++ b/lib/splash_page.dart
@@ -69,13 +69,13 @@ class _SplashPageState extends State<SplashPage> {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
       if (mounted) {
-        await Navigator.pushNamed(context, IntroPage.path);
+        await Navigator.pushReplacementNamed(context, IntroPage.path);
       }
       return;
     }
 
     if (mounted) {
-      await Navigator.pushNamed(context, HomePage.path);
+      await Navigator.pushReplacementNamed(context, HomePage.path);
     }
   }
 }

--- a/lib/views/pages/account/account_page.dart
+++ b/lib/views/pages/account/account_page.dart
@@ -15,6 +15,14 @@ class AccountPage extends StatefulWidget {
 }
 
 class _AccountPageState extends State<AccountPage> {
+  // ログアウトボタンを押した時の処理
+  Function onPressedLogoutButton = () {
+    // ログアウト
+    final auth = FirebaseAuth.instance;
+    GoogleSignIn().signOut();
+    auth.signOut();
+  };
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -28,13 +36,7 @@ class _AccountPageState extends State<AccountPage> {
           children: [
             SettingsTile(title: 'アカウント情報', onPressed: () {}),
             SettingsTile(title: 'パスワード', onPressed: () {}),
-            SettingsTile(
-                title: 'ログアウト',
-                onPressed: () {
-                  final auth = FirebaseAuth.instance;
-                  GoogleSignIn().signOut();
-                  auth.signOut();
-                }),
+            SettingsTile(title: 'ログアウト', onPressed: onPressedLogoutButton()),
             SettingsTile(title: 'アカウントの削除', onPressed: () {}),
             const BorderWidget()
           ],

--- a/lib/views/pages/account/account_page.dart
+++ b/lib/views/pages/account/account_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:withtone/splash_page.dart';
 import 'package:withtone/views/components/border_widget.dart';
 import 'package:withtone/views/components/settings_tile.dart';
 
@@ -16,11 +17,16 @@ class AccountPage extends StatefulWidget {
 
 class _AccountPageState extends State<AccountPage> {
   // ログアウトボタンを押した時の処理
-  Function onPressedLogoutButton = () {
+  Function onPressedLogoutButton = (BuildContext context) {
     // ログアウト
     final auth = FirebaseAuth.instance;
     GoogleSignIn().signOut();
     auth.signOut();
+    // ログイン前の画面に戻る
+    Navigator.of(context).pushNamedAndRemoveUntil(
+      SplashPage.path,
+      (_) => false,
+    );
   };
 
   @override
@@ -36,7 +42,10 @@ class _AccountPageState extends State<AccountPage> {
           children: [
             SettingsTile(title: 'アカウント情報', onPressed: () {}),
             SettingsTile(title: 'パスワード', onPressed: () {}),
-            SettingsTile(title: 'ログアウト', onPressed: onPressedLogoutButton()),
+            SettingsTile(
+              title: 'ログアウト',
+              onPressed: () => onPressedLogoutButton(context),
+            ),
             SettingsTile(title: 'アカウントの削除', onPressed: () {}),
             const BorderWidget()
           ],

--- a/lib/views/pages/account/account_page.dart
+++ b/lib/views/pages/account/account_page.dart
@@ -16,8 +16,7 @@ class AccountPage extends StatefulWidget {
 }
 
 class _AccountPageState extends State<AccountPage> {
-  // ログアウトボタンを押した時の処理
-  Function onPressedLogoutButton = (BuildContext context) {
+  Function logoutAndTransitionSplashPage = (BuildContext context) {
     // ログアウト
     final auth = FirebaseAuth.instance;
     GoogleSignIn().signOut();
@@ -28,6 +27,44 @@ class _AccountPageState extends State<AccountPage> {
       (_) => false,
     );
   };
+
+  ///BottomSheetを表示
+  void _showBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return SizedBox(
+          height: 240,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Column(
+              children: <Widget>[
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 30),
+                  child: Text(
+                    '本当にログアウトしますか',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                const BorderWidget(color: Color(0xffD0D1D3)),
+                ListTile(
+                  title: const Text('ログアウト', textAlign: TextAlign.center),
+                  onTap: () => logoutAndTransitionSplashPage(context),
+                ),
+                const BorderWidget(color: Color(0xffD0D1D3)),
+                ListTile(
+                  title: const Text('戻る', textAlign: TextAlign.center),
+                  onTap: () => Navigator.pop(context),
+                ),
+                const BorderWidget(color: Color(0xffD0D1D3)),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +81,7 @@ class _AccountPageState extends State<AccountPage> {
             SettingsTile(title: 'パスワード', onPressed: () {}),
             SettingsTile(
               title: 'ログアウト',
-              onPressed: () => onPressedLogoutButton(context),
+              onPressed: () => _showBottomSheet(context),
             ),
             SettingsTile(title: 'アカウントの削除', onPressed: () {}),
             const BorderWidget()


### PR DESCRIPTION
## 関連する issue 

#110 (残あり)

## やりたかったこと

ログアウトで画面遷移しなかったので、Splashまで戻るようにしたかった。

## やったこと

上記 issue のうち、ログアウト関連のみやった。

- ログアウトした後の画面遷移を追加 [8861c9f](https://github.com/Mayumi-Nakabayashi/withTone/pull/135/commits/8861c9fb15735ebf3b14124989b5a5a7df183bb6), [462014e](https://github.com/Mayumi-Nakabayashi/withTone/pull/135/commits/462014e8350653dc19909dafd1f977c31ed0b22e)
- モーダル表示追加

ついでに、動作確認で気になった箇所の画面遷移の方法を調整した。 [871a3f0](https://github.com/Mayumi-Nakabayashi/withTone/pull/135/commits/871a3f09c377e1cee8208b5ce6ecb5e3e681b679)
参考: https://medium.com/@katsummy/flutter%E3%81%AEnavigator%E3%81%A7%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB-c3f5a358a54d

## やらなかったこと

上記 issue のうち、バージョン表示のところ。
残があるので issue は close しない。残りは Ph2 にやる。

## 確認

ログアウトモーダルが表示されること。
ログアウトしたら画面が Splash まで戻り、ログイン判定（ログインしてない） → ログイン画面に遷移すること。

https://github.com/Mayumi-Nakabayashi/withTone/assets/38717219/a07c5e7e-44f4-4908-a26c-5f5e1cab83e4