### PR TITLE
ユーザー登録エラー時の動作を調整

### DIFF
--- a/lib/views/pages/signup_mail/signup_mail.dart
+++ b/lib/views/pages/signup_mail/signup_mail.dart
@@ -25,6 +25,13 @@ class _SignupMailPageState extends State<SignupMailPage> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
 
+  @override
+  void dispose() {
+    emailController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
+
   String errorText = '';
 
   /// 新規ユーザー仮登録実行

--- a/lib/views/pages/signup_mail/signup_mail.dart
+++ b/lib/views/pages/signup_mail/signup_mail.dart
@@ -25,13 +25,27 @@ class _SignupMailPageState extends State<SignupMailPage> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
 
+  String errorText = '';
+
   /// 新規ユーザー仮登録実行
-  Future<UserCredential> _signup(String email, String password) async {
-    final result = await FirebaseAuth.instance.createUserWithEmailAndPassword(
-      email: email,
-      password: password,
-    );
-    return result;
+  Future<void> _signup({
+    required String email,
+    required String password,
+    required VoidCallback successCallback,
+  }) async {
+    try {
+      final result = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      // メール認証を送信
+      await result.user?.sendEmailVerification();
+      successCallback();
+    } catch (e) {
+      setState(() {
+        errorText = e.toString();
+      });
+    }
   }
 
   @override
@@ -43,7 +57,17 @@ class _SignupMailPageState extends State<SignupMailPage> {
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: Column(
             children: [
-              const SizedBox(height: 100),
+              errorText.isNotEmpty
+                  ? Container(
+                      padding: const EdgeInsets.all(40),
+                      width: double.infinity,
+                      child: Text(
+                        errorText,
+                        textAlign: TextAlign.left,
+                        style: const TextStyle(color: Color(0xffFF0000)),
+                      ),
+                    )
+                  : const SizedBox(height: 100),
               const SizedBox(
                 width: double.infinity,
                 child: Text(
@@ -111,23 +135,25 @@ class _SignupMailPageState extends State<SignupMailPage> {
               PrimaryButton(
                 label: '登録',
                 onPressed: () async {
-                  final email = emailController.text;
-                  final password = passwordController.text;
-                  final result = await _signup(email, password);
-                  await result.user!.sendEmailVerification();
-                  if (mounted) {
-                    ///引数で渡したいため,routesで画面遷移させていない
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: ((context) => EmailSendCheck(
-                              email: email,
-                              password: password,
+                  await _signup(
+                    email: emailController.text,
+                    password: passwordController.text,
+                    successCallback: () {
+                      if (mounted) {
+                        ///引数で渡したいため,routesで画面遷移させていない
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => EmailSendCheck(
+                              email: emailController.text,
+                              password: passwordController.text,
                               from: 1,
-                            )),
-                      ),
-                    );
-                  }
+                            ),
+                          ),
+                        );
+                      }
+                    },
+                  );
                 },
               ),
             ],

--- a/lib/views/pages/signup_mail/signup_mail.dart
+++ b/lib/views/pages/signup_mail/signup_mail.dart
@@ -25,6 +25,15 @@ class _SignupMailPageState extends State<SignupMailPage> {
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
 
+  /// 新規ユーザー仮登録実行
+  Future<UserCredential> _signup(String email, String password) async {
+    final result = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -104,9 +113,7 @@ class _SignupMailPageState extends State<SignupMailPage> {
                 onPressed: () async {
                   final email = emailController.text;
                   final password = passwordController.text;
-                  final result = await FirebaseAuth.instance
-                      .createUserWithEmailAndPassword(
-                          email: email, password: password);
+                  final result = await _signup(email, password);
                   await result.user!.sendEmailVerification();
                   if (mounted) {
                     ///引数で渡したいため,routesで画面遷移させていない


### PR DESCRIPTION
## やりたかったこと

#72 (残あり) > 登録メールのエラーハンドリング

## やったこと

asis: メールでユーザー登録する際に、メアドが登録済みの時などでも画面遷移していた。
tobe: エラーの場合は画面上部にエラー文言が表示され、画面遷移しない。

[32dba3f](https://github.com/Mayumi-Nakabayashi/withTone/pull/138/commits/32dba3f0b717b385867e6f7240b17e41661a787e), [114fd93](https://github.com/Mayumi-Nakabayashi/withTone/pull/138/commits/114fd931e3fa216dd6e66959491a83537d12866d)

### ついでにやったこと

TextEditingController の dispose 処理がなかったので追加した。 [9b01f7b](https://github.com/Mayumi-Nakabayashi/withTone/pull/138/commits/9b01f7b610577d31a65bc1e2d2b35cdc5861536a)

## 確認

成功時:

https://github.com/Mayumi-Nakabayashi/withTone/assets/38717219/ddf99962-03ff-4356-92f5-3f48b8f1ff03




失敗時 ( 想定通り画面遷移しなくなった ):

https://github.com/Mayumi-Nakabayashi/withTone/assets/38717219/345c3e62-5af3-4674-8e0a-9f0ffce3f102


